### PR TITLE
Let ToolProvidedMetadata interface more directly decide if it has failed outputs.

### DIFF
--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -32,6 +32,9 @@ class NullToolProvidedMetadata(object):
     def get_new_dataset_meta_by_basename(self, output_name, basename):
         return {}
 
+    def has_failed_outputs(self):
+        return False
+
 
 class LegacyToolProvidedMetadata(object):
 
@@ -74,6 +77,14 @@ class LegacyToolProvidedMetadata(object):
         log.warning("Called get_new_datasets with legacy tool metadata provider - that is unimplemented.")
         return []
 
+    def has_failed_outputs(self):
+        found_failed = False
+        for meta in self.tool_provided_job_metadata:
+            if meta.get("failed", False):
+                found_failed = True
+
+        return found_failed
+
 
 class ToolProvidedMetadata(object):
 
@@ -111,6 +122,14 @@ class ToolProvidedMetadata(object):
                 dataset = extra_kwds
                 extra_kwds.update(element)
                 yield extra_kwds
+
+    def has_failed_outputs(self):
+        found_failed = False
+        for meta in self.tool_provided_job_metadata.values():
+            if meta.get("failed", False):
+                found_failed = True
+
+        return found_failed
 
 
 def collect_dynamic_collections(

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -43,7 +43,8 @@ def file_err(msg, dataset, json_file):
     json_file.write(dumps(dict(type='dataset',
                                ext='data',
                                dataset_id=dataset.dataset_id,
-                               stderr=msg)) + "\n")
+                               stderr=msg,
+                               failed=True)) + "\n")
     # never remove a server-side upload
     if dataset.type in ('server_dir', 'path_paste'):
         return


### PR DESCRIPTION
I like this better for a few reasons:

- Since usually it is scripts producing this JSON - we have the most control at that point for determining the failure and we don't have to deal with an artificial dependency between the tool's stdio and the output. The script can directly set.
- At some point we could potentially allow some datasets to be ok now even though the job fails - and it doesn't artificially aggregate the stderr data that is produced separately.
- It is a cleaner interface at the Python level between job finish and output collection IMO (no need for ``isinstance`` checking). (This last point is a bit less relevant because aggregating the standard error could easily be done the same behind that interface - it was me starting to do that got me to realize I'd prefer to be more direct about this.)
