### PR TITLE
Add tagging support for workflow invocations

### DIFF
--- a/client/src/components/Grid/configs/invocations.ts
+++ b/client/src/components/Grid/configs/invocations.ts
@@ -3,6 +3,7 @@ import { useEventBus } from "@vueuse/core";
 
 import { GalaxyApi } from "@/api";
 import type { WorkflowInvocation } from "@/api/invocations";
+import { updateTags } from "@/api/tags";
 import type { StoredWorkflowDetailed } from "@/api/workflows";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
@@ -119,6 +120,19 @@ const fields: FieldArray = [
         key: "create_time",
         title: "Invoked",
         type: "date",
+    },
+    {
+        key: "tags",
+        title: "Tags",
+        type: "tags",
+        handler: async (data) => {
+            const invocation = data as WorkflowInvocation;
+            try {
+                await updateTags(invocation.id, "WorkflowInvocation", invocation.tags ?? undefined);
+            } catch (e) {
+                rethrowSimple(e);
+            }
+        },
     },
     {
         key: "state",

--- a/client/src/components/Grid/configs/invocationsBatch.ts
+++ b/client/src/components/Grid/configs/invocationsBatch.ts
@@ -1,7 +1,9 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
 
 import type { WorkflowInvocation } from "@/api/invocations";
+import { updateTags } from "@/api/tags";
 import { getAppRoot } from "@/onload";
+import { rethrowSimple } from "@/utils/simple-error";
 
 import type { FieldArray, GridConfig } from "./types";
 
@@ -51,6 +53,19 @@ const fields: FieldArray = [
         key: "create_time",
         title: "Invoked",
         type: "date",
+    },
+    {
+        key: "tags",
+        title: "Tags",
+        type: "tags",
+        handler: async (data) => {
+            const invocation = data as WorkflowInvocation;
+            try {
+                await updateTags(invocation.id, "WorkflowInvocation", invocation.tags ?? undefined);
+            } catch (e) {
+                rethrowSimple(e);
+            }
+        },
     },
     {
         key: "state",

--- a/client/src/components/Grid/configs/invocationsHistory.ts
+++ b/client/src/components/Grid/configs/invocationsHistory.ts
@@ -3,6 +3,7 @@ import { useEventBus } from "@vueuse/core";
 
 import { GalaxyApi } from "@/api";
 import type { WorkflowInvocation } from "@/api/invocations";
+import { updateTags } from "@/api/tags";
 import type { StoredWorkflowDetailed } from "@/api/workflows";
 import { useUserStore } from "@/stores/userStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
@@ -111,6 +112,19 @@ const fields: FieldArray = [
         key: "create_time",
         title: "Invoked",
         type: "date",
+    },
+    {
+        key: "tags",
+        title: "Tags",
+        type: "tags",
+        handler: async (data) => {
+            const invocation = data as WorkflowInvocation;
+            try {
+                await updateTags(invocation.id, "WorkflowInvocation", invocation.tags ?? undefined);
+            } catch (e) {
+                rethrowSimple(e);
+            }
+        },
     },
     {
         key: "state",

--- a/client/src/components/Grid/configs/invocationsWorkflow.ts
+++ b/client/src/components/Grid/configs/invocationsWorkflow.ts
@@ -3,6 +3,7 @@ import { useEventBus } from "@vueuse/core";
 
 import { GalaxyApi } from "@/api";
 import type { WorkflowInvocation } from "@/api/invocations";
+import { updateTags } from "@/api/tags";
 import type { StoredWorkflowDetailed } from "@/api/workflows";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
@@ -115,6 +116,19 @@ const fields: FieldArray = [
         key: "create_time",
         title: "Invoked",
         type: "date",
+    },
+    {
+        key: "tags",
+        title: "Tags",
+        type: "tags",
+        handler: async (data) => {
+            const invocation = data as WorkflowInvocation;
+            try {
+                await updateTags(invocation.id, "WorkflowInvocation", invocation.tags ?? undefined);
+            } catch (e) {
+                rethrowSimple(e);
+            }
+        },
     },
     {
         key: "state",

--- a/client/src/components/Workflow/test/json/invocation.json
+++ b/client/src/components/Workflow/test/json/invocation.json
@@ -7,6 +7,7 @@
     "history_id": "78ea7964263eadc1",
     "uuid": "01127b40-4eb4-11eb-baba-acde48001122",
     "state": "scheduled",
+    "tags": ["tag1", "tag2"],
     "steps": [
         {
             "model_class": "WorkflowInvocationStep",

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
@@ -20,6 +20,8 @@ const selectors = {
     invocationReportTab: ".invocation-report-tab",
     invocationExportTab: ".invocation-export-tab",
     fullPageHeading: "anonymous-stub[h1='true']",
+    invocationTagsSection: ".invocation-tags-section",
+    statelessTagsStub: "statelesstags-stub",
 };
 
 /** Invocation data to be expected in the store */
@@ -92,6 +94,12 @@ const mockFetchInvocationById = vi.fn().mockImplementation((fetchParams) => {
     }
 });
 const mockFetchInvocationJobsSummaryForId = vi.fn();
+const mockUpdateTags = vi.fn().mockResolvedValue(undefined);
+
+// Mock the updateTags function
+vi.mock("@/api/tags", () => ({
+    updateTags: (...args: unknown[]) => mockUpdateTags(...args),
+}));
 
 // Mock the invocation store to return the expected invocation data given the invocation ID
 vi.mock("@/stores/invocationStore", async () => {
@@ -264,6 +272,38 @@ describe("WorkflowInvocationState check 'Debug' tab", () => {
         const wrapper = await mountWorkflowInvocationState("terminal-error-jobs", true);
         expect(isInvocationAndJobTerminal(wrapper)).toBe(true);
         expect(wrapper.find(selectors.invocationDebugTab).exists()).toBe(true);
+    });
+});
+
+describe("WorkflowInvocationState tags section", () => {
+    beforeEach(() => {
+        mockUpdateTags.mockClear();
+        mockFetchInvocationById.mockClear();
+    });
+
+    it("displays tags section on full page view", async () => {
+        const wrapper = await mountWorkflowInvocationState(invocationData.id, true);
+        const tagsSection = wrapper.find(selectors.invocationTagsSection);
+        expect(tagsSection.exists()).toBe(true);
+    });
+
+    it("does not display tags section when not full page", async () => {
+        const wrapper = await mountWorkflowInvocationState(invocationData.id, false);
+        const tagsSection = wrapper.find(selectors.invocationTagsSection);
+        expect(tagsSection.exists()).toBe(false);
+    });
+
+    it("includes invocation tags label", async () => {
+        const wrapper = await mountWorkflowInvocationState(invocationData.id, true);
+        const tagsSection = wrapper.find(selectors.invocationTagsSection);
+        expect(tagsSection.text()).toContain("Invocation Tags:");
+    });
+
+    it("passes invocation tags to StatelessTags component", async () => {
+        const wrapper = await mountWorkflowInvocationState(invocationData.id, true);
+        const tagsSection = wrapper.find(selectors.invocationTagsSection);
+        // Verify the tags are passed to the component (value attribute contains the tags)
+        expect(tagsSection.html()).toContain('value="tag1,tag2"');
     });
 });
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -5,9 +5,10 @@ import { BAlert, BBadge, BNav, BNavItem } from "bootstrap-vue";
 import { computed, onUnmounted, ref, watch } from "vue";
 
 import { type InvocationStep, isWorkflowInvocationElementView } from "@/api/invocations";
+import { updateTags } from "@/api/tags";
 import { useInvocationStore } from "@/stores/invocationStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
-import { errorMessageAsString } from "@/utils/simple-error";
+import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
 
 import {
     errorCount as jobStatesSummaryErrorCount,
@@ -32,6 +33,7 @@ import WorkflowInvocationMetrics from "./WorkflowInvocationMetrics.vue";
 import WorkflowInvocationOverview from "./WorkflowInvocationOverview.vue";
 import WorkflowInvocationShare from "./WorkflowInvocationShare.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
+import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
 interface Props {
     invocationId: string;
@@ -271,6 +273,21 @@ async function onCancel() {
         cancellingInvocation.value = false;
     }
 }
+
+const invocationTags = computed(() => invocation.value?.tags ?? []);
+
+async function onTagsUpdate(newTags: string[]) {
+    if (!invocation.value) {
+        return;
+    }
+    try {
+        await updateTags(invocation.value.id, "WorkflowInvocation", newTags);
+        // Refresh the invocation to get updated tags
+        await invocationStore.fetchInvocationById({ id: props.invocationId });
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
 </script>
 
 <template>
@@ -343,6 +360,11 @@ async function onCancel() {
                 </div>
             </template>
         </WorkflowAnnotation>
+
+        <div v-if="props.isFullPage" class="invocation-tags-section px-2 pb-2">
+            <span class="font-weight-bold mr-2">Invocation Tags:</span>
+            <StatelessTags :value="invocationTags" @input="onTagsUpdate" />
+        </div>
 
         <BNav v-if="props.isFullPage" pills class="mb-2 p-2 bg-light border-bottom">
             <BNavItem title="Overview" :active="onOverviewTab" :to="`/workflows/invocations/${props.invocationId}`">

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1077,6 +1077,10 @@ invocations:
     wizard_next_button: '.wizard-actions .go-next-btn'
     wizard_export_button: '.wizard-actions .go-next-btn.btn-primary'
     export_download_link: '.download-link'
+    tags_section: '.invocation-tags-section'
+    tags_toggle: '.invocation-tags-section .stateless-tags .toggle-button'
+    tags_input: '.invocation-tags-section .stateless-tags .headless-multiselect input'
+    tags_display: '.invocation-tags-section .stateless-tags .tag'
 
 tour:
   popover:

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -20,6 +20,7 @@ class TaggableItemClass(Enum):
     Page = "Page"
     StoredWorkflow = "StoredWorkflow"
     Visualization = "Visualization"
+    WorkflowInvocation = "WorkflowInvocation"
 
 
 class ItemTagsPayload(Model):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9297,7 +9297,7 @@ class InputToMaterialize:
     ]
 
 
-class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializable):
+class WorkflowInvocation(Base, HasTags, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     __tablename__ = "workflow_invocation"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -9347,6 +9347,10 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         back_populates="workflow_invocation",
         uselist=False,
     )
+    tags: Mapped[list["WorkflowInvocationTagAssociation"]] = relationship(
+        order_by=lambda: WorkflowInvocationTagAssociation.id,
+        back_populates="workflow_invocation",
+    )
 
     dict_collection_visible_keys = [
         "id",
@@ -9356,6 +9360,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         "history_id",
         "uuid",
         "state",
+        "tags",
     ]
     dict_element_visible_keys = [
         "id",
@@ -9365,6 +9370,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         "history_id",
         "uuid",
         "state",
+        "tags",
     ]
 
     states = InvocationState
@@ -11493,6 +11499,20 @@ class VisualizationTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     visualization: Mapped["Visualization"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
+
+
+class WorkflowInvocationTagAssociation(Base, ItemTagAssociation, RepresentById):
+    __tablename__ = "workflow_invocation_tag_association"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    workflow_invocation_id: Mapped[int] = mapped_column(ForeignKey("workflow_invocation.id"), index=True, nullable=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
+    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
+    user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
+    value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
+    workflow_invocation: Mapped["WorkflowInvocation"] = relationship(back_populates="tags")
     tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9427,6 +9427,11 @@ class WorkflowInvocation(Base, HasTags, UsesCreateAndUpdateTime, Dictifiable, Se
         states = WorkflowInvocation.states
         return self.state in [states.NEW, states.READY]
 
+    @property
+    def user(self):
+        """Returns the user who owns this invocation (via the history)."""
+        return self.history.user if self.history else None
+
     def set_state(self, state: InvocationState):
         session = object_session(self)
         priority_states = (WorkflowInvocation.states.CANCELLING, WorkflowInvocation.states.CANCELLED)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b926bc33a62c_add_workflow_invocation_tag_association.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b926bc33a62c_add_workflow_invocation_tag_association.py
@@ -1,0 +1,37 @@
+"""Add workflow_invocation_tag_association table
+
+Revision ID: b926bc33a62c
+Revises: 75b461a2b24a
+Create Date: 2026-01-03 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrations.util import (
+    create_table,
+    drop_table,
+)
+
+# revision identifiers, used by Alembic.
+revision = "b926bc33a62c"
+down_revision = "75b461a2b24a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_table(
+        "workflow_invocation_tag_association",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("workflow_invocation_id", sa.Integer, sa.ForeignKey("workflow_invocation.id"), index=True),
+        sa.Column("tag_id", sa.Integer, sa.ForeignKey("tag.id"), index=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("galaxy_user.id"), index=True),
+        sa.Column("user_tname", TrimmedString(255), index=True),
+        sa.Column("value", TrimmedString(255), index=True),
+    )
+
+
+def downgrade():
+    drop_table("workflow_invocation_tag_association")

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -493,6 +493,11 @@ class GalaxyTagHandler(TagHandler):
                 model.VisualizationTagAssociation,
                 model.VisualizationTagAssociation.visualization_id,
             ),
+            "WorkflowInvocation": ItemTagAssocInfo(
+                model.WorkflowInvocation,
+                model.WorkflowInvocationTagAssociation,
+                model.WorkflowInvocationTagAssociation.workflow_invocation_id,
+            ),
         }
         return cls._item_tag_assoc_info
 

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -42,6 +42,7 @@ from galaxy.schema.schema import (
     JobState,
     Model,
     StoreContentSource,
+    TagCollection,
     UpdateTimeField,
     WithModelClass,
 )
@@ -595,6 +596,11 @@ class WorkflowInvocationCollectionView(Model, WithModelClass):
         default=None,
         title="Landing UUID",
         description="The UUID of the workflow landing request associated with this invocation.",
+    )
+    tags: Optional[TagCollection] = Field(
+        default=None,
+        title="Tags",
+        description="Tags associated with the workflow invocation.",
     )
     model_class: INVOCATION_MODEL_CLASS = ModelClassField(INVOCATION_MODEL_CLASS)
 

--- a/lib/galaxy/webapps/galaxy/api/item_tags.py
+++ b/lib/galaxy/webapps/galaxy/api/item_tags.py
@@ -116,6 +116,7 @@ prefixes = {
     "histories": ["History", "history_id", "histories"],
     "histories/{history_id}/contents": ["HistoryDatasetAssociation", "history_content_id", "histories"],
     "workflows": ["StoredWorkflow", "workflow_id", "workflows"],
+    "invocations": ["WorkflowInvocation", "invocation_id", "invocations"],
 }
 for prefix, tagged_item in prefixes.items():
     tagged_item_class, tagged_item_id, api_docs_tag = tagged_item

--- a/lib/galaxy_test/api/test_item_tags.py
+++ b/lib/galaxy_test/api/test_item_tags.py
@@ -83,10 +83,48 @@ class TestItemTagsApi(ApiTestCase):
         response = self._test_delete_tag(self._create_prefix("histories_content"))
         self._assert_status_code_is(response, 200)
 
+    def test_get_tags_invocations(self):
+        response = self._test_get_tags(self._create_prefix("invocations"))
+        self._assert_status_code_is(response, 200)
+
+    def test_create_tag_invocations(self):
+        response = self._test_create_tag(self._create_prefix("invocations"))
+        self._assert_status_code_is(response, 200)
+
+    def test_update_tag_invocations(self):
+        response = self._test_update_tag(self._create_prefix("invocations"))
+        self._assert_status_code_is(response, 200)
+
+    def test_get_tag_invocations(self):
+        response = self._test_get_tag(self._create_prefix("invocations"))
+        self._assert_status_code_is(response, 200)
+
+    def test_delete_tag_invocations(self):
+        response = self._test_delete_tag(self._create_prefix("invocations"))
+        self._assert_status_code_is(response, 200)
+
+    def test_invocation_tags_in_response(self):
+        """Test that tags appear in invocation response after being set."""
+        prefix = self._create_prefix("invocations")
+        invocation_id = prefix.split("/")[1]
+
+        # Create a tag
+        self._create_valid_tag(prefix)
+
+        # Verify tag appears in invocation response
+        response = self._get(f"invocations/{invocation_id}")
+        self._assert_status_code_is(response, 200)
+        invocation = response.json()
+        assert "tags" in invocation
+        assert "awesometagname" in invocation["tags"]
+
     def _create_prefix(self, type_: str) -> str:
         if type_ == "workflows":
             workflow_id = self._create_workflow()
             return f"workflows/{workflow_id}"
+        if type_ == "invocations":
+            invocation_id = self._create_invocation()
+            return f"invocations/{invocation_id}"
         history_id = self._create_history()
         if type_ == "histories":
             return f"histories/{history_id}"
@@ -147,3 +185,25 @@ class TestItemTagsApi(ApiTestCase):
         workflow = self.workflow_populator.load_workflow_from_resource(name="test_workflow_with_input_tags")
         workflow_id = self.workflow_populator.create_workflow(workflow)
         return workflow_id
+
+    def _create_invocation(self):
+        history_id = self._create_history()
+        summary = self.workflow_populator.run_workflow(
+            """
+class: GalaxyWorkflow
+name: Simple Workflow
+inputs:
+  input1: data
+outputs:
+  wf_output_1:
+    outputSource: first_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+""",
+            test_data={"input1": "hello world"},
+            history_id=history_id,
+        )
+        return summary.invocation_id

--- a/lib/galaxy_test/selenium/test_workflow_invocation_details.py
+++ b/lib/galaxy_test/selenium/test_workflow_invocation_details.py
@@ -1,6 +1,7 @@
 from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_KEEP_SUCCESSFUL_DATASETS,
     WORKFLOW_KEEP_SUCCESSFUL_DATASETS_TEST_DATA,
+    WORKFLOW_SIMPLE_CAT_TWICE,
     WORKFLOW_WITH_OUTPUT_COLLECTION,
 )
 from .framework import (
@@ -140,3 +141,59 @@ class TestWorkflowInvocationDetails(SeleniumTestCase):
 
         # close invocations panel
         self.components.invocations.activity.wait_for_and_click()
+
+    @selenium_test
+    @managed_history
+    def test_invocation_tags(self):
+        """Test that workflow invocation tags can be viewed and edited.
+
+        This test verifies:
+        - Tags section is displayed on the invocation panel view
+        - Tags can be added to an invocation
+        - Added tags are displayed correctly
+        """
+        gx_selenium_context = self
+        history_id = gx_selenium_context.current_history_id()
+
+        # Run a simple workflow
+        gx_selenium_context.workflow_populator.run_workflow(
+            WORKFLOW_SIMPLE_CAT_TWICE,
+            test_data={"input1": "hello world"},
+            history_id=history_id,
+            assert_ok=True,
+            wait=True,
+        )
+
+        # Open the invocation via the invocations panel
+        self.invocation_open_latest()
+        invocations = self.components.invocations
+
+        # Verify tags section is present
+        invocations.tags_section.wait_for_visible()
+        self.screenshot("invocation_tags_section_visible")
+
+        # Click the tags toggle button to add tags
+        invocations.tags_toggle.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # Add a tag using the tags input
+        from selenium.webdriver.common.keys import Keys
+
+        invocations.tags_input.wait_for_visible()
+        invocations.tags_input.wait_for_and_send_keys("selenium-test-tag")
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        # Press enter to confirm the tag
+        invocations.tags_input.wait_for_visible().send_keys(Keys.ENTER)
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # Verify the tag appears
+        @retry_assertion_during_transitions
+        def assert_tag_visible():
+            tags = invocations.tags_display.all()
+            assert len(tags) > 0
+            tag_texts = [tag.text for tag in tags]
+            assert any("selenium-test-tag" in text for text in tag_texts)
+
+        assert_tag_visible()
+        self.screenshot("invocation_tag_added")


### PR DESCRIPTION
This change enables users to tag workflow invocations and display those
tags throughout the UI. The implementation includes:

Backend changes:
- Add WorkflowInvocationTagAssociation model for storing invocation tags
- Add HasTags mixin to WorkflowInvocation model with tags relationship
- Register WorkflowInvocation in GalaxyTagHandler for tag operations
- Add WorkflowInvocation to TaggableItemClass enum
- Add API routes for invocation tag CRUD operations (/api/invocations/{id}/tags)
- Add tags field to invocation schema responses
- Add database migration for workflow_invocation_tag_association table

Frontend changes:
- Add tags column to all invocation grid views (main, workflow, history, batch)
- Display editable tags in WorkflowInvocationState detail view
- Integrate with existing updateTags API client