### PR TITLE
Share versionless-lineage bookkeeping between LineageMap and CachedLineageMap

### DIFF
--- a/lib/galaxy/tool_util/toolbox/lineages/factory.py
+++ b/lib/galaxy/tool_util/toolbox/lineages/factory.py
@@ -23,21 +23,32 @@ class LineageMap:
     def register(self, tool: "Tool") -> ToolLineage:
         tool_id = tool.id
         assert tool_id
-        versionless_tool_id = remove_version_from_guid(tool_id)
-        lineage: ToolLineage
-        if versionless_tool_id not in self.lineage_map:
-            lineage = ToolLineage.from_tool(tool)
-        else:
-            lineage = self.lineage_map[versionless_tool_id]
-            # A lineage for a tool with the same versionless_tool_id exists,
-            # but this lineage may not have the current tools' version,
-            # so we add tool.version to the lineage
-            lineage.register_version(tool.version)
-        if versionless_tool_id and versionless_tool_id not in self.lineage_map:
-            self.lineage_map[versionless_tool_id] = lineage
-        if tool_id not in self.lineage_map:
-            self.lineage_map[tool_id] = lineage
+        # An existing lineage may not have the current tool's version yet, so
+        # register it either way. The map entry can be an older, unshared
+        # lineage (`get` aliases a tool_id without its versionless key), and
+        # that is what callers have always been handed back.
+        lineage = self._shared_lineage(tool_id, lambda: ToolLineage.from_tool(tool))
+        lineage.register_version(tool.version)
         return self.lineage_map[tool_id]
+
+    def _shared_lineage(self, tool_id: str, build: Callable[[], ToolLineage]) -> ToolLineage:
+        """Return the lineage `tool_id` contributes its versions to.
+
+        Every tool_id sharing a versionless guid resolves to one lineage
+        object, and the map is keyed under both. Callers depend on that
+        sharing: `ToolSection.copy(merge_tools=True)` dedups panel entries by
+        lineage, so two installed revisions of the same tool must collapse.
+        The versionless key wins, so a lineage reached by any one version
+        accumulates them all; `build` runs only when neither key is mapped.
+        """
+        versionless_tool_id = remove_version_from_guid(tool_id)
+        lineage = self.lineage_map.get(versionless_tool_id) if versionless_tool_id else None
+        if lineage is None:
+            lineage = self.lineage_map.get(tool_id) or build()
+        if versionless_tool_id:
+            self.lineage_map.setdefault(versionless_tool_id, lineage)
+        self.lineage_map.setdefault(tool_id, lineage)
+        return lineage
 
     def get(self, tool_id: str) -> ToolLineage | None:
         """
@@ -88,45 +99,24 @@ class CachedLineageMap(LineageMap):
         self._versions_for = versions_for
 
     def get(self, tool_id: str) -> ToolLineage | None:
-        # Always source versions from the index when available — the parent's
-        # fallback path builds a lineage from a single ``Tool`` object's
-        # version (via ``ToolLineage.from_tool``) and memoises it, which
-        # would freeze ``tool_versions`` at ``[just-loaded version]`` and
-        # hide every other version present in the index. That breaks
-        # ``get_safe_version`` (used by ``ToolModule.__init__`` at workflow
-        # upload to map a pinned-but-missing tool_version onto the nearest
-        # safe-upgrade version, e.g. ``__BUILD_LIST__`` 1.0.0 → 1.1.0): it
-        # walks ``tool.lineage.tool_versions`` and only finds candidates
-        # within ``WORKFLOW_SAFE_TOOL_VERSION_UPDATES``' bounds, so a
-        # one-element ``[1.2.0]`` lineage misses 1.1.0 and the workflow
-        # ends up bound to 1.2.0 with state shaped for 1.0.0.
+        # An eager toolbox seeds every version through ``register`` as it
+        # loads tools, so ``LineageMap.get`` is only ever a lookup. Nothing
+        # walks the tools here, so ``get`` is the construction path and has
+        # to source versions from the index — the inherited fallback would
+        # build a lineage from a single just-loaded ``Tool`` and memoise it,
+        # freezing ``tool_versions`` at one entry and hiding the rest. That
+        # breaks ``get_safe_version`` (``ToolModule.__init__`` maps a
+        # pinned-but-missing tool_version onto the nearest safe upgrade,
+        # e.g. ``__BUILD_LIST__`` 1.0.0 → 1.1.0): a one-element ``[1.2.0]``
+        # lineage misses 1.1.0, so the workflow binds to 1.2.0 with state
+        # shaped for 1.0.0.
         if self._versions_for is not None:
             try:
                 versions = list(self._versions_for(tool_id))
             except Exception:
                 versions = []
             if versions:
-                # Share the lineage object across every tool_id that maps
-                # to the same versionless guid — eager ``LineageMap.register``
-                # does this via the ``versionless_tool_id`` key, and tools
-                # rely on it for ``ToolSection.copy(merge_tools=True)``.
-                # Without sharing, two shed installs of the same tool (e.g.
-                # ``fastp/0.19.5+galaxy1`` and ``fastp/0.20.1+galaxy0``) get
-                # distinct ``ToolLineage`` objects whose ``tool_versions``
-                # only carry the version that happened to be in the index
-                # at first lookup. ``test_only_latest_version_in_panel_fastp``
-                # then sees both tools survive lineage dedup (with
-                # ``tools[0]`` reflecting whichever was inserted first into
-                # ``section.elems`` instead of the newest version).
-                versionless = remove_version_from_guid(tool_id)
-                lineage = self.lineage_map.get(tool_id)
-                if lineage is None and versionless:
-                    lineage = self.lineage_map.get(versionless)
-                if lineage is None:
-                    lineage = ToolLineage(tool_id)
-                    if versionless:
-                        self.lineage_map[versionless] = lineage
-                self.lineage_map[tool_id] = lineage
+                lineage = self._shared_lineage(tool_id, lambda: ToolLineage(tool_id))
                 for version in versions:
                     if version:
                         lineage.register_version(version)


### PR DESCRIPTION
> 🤖 **Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.** Opened against `lazy-toolbox-atomic` so the suggestion is reviewable in context rather than as a review comment. Take it, tweak it, or close it.

While reviewing #22633 I got stuck on the comment at the top of `CachedLineageMap.get` — it explains *what* goes wrong (frozen `tool_versions`, broken `get_safe_version`) but never states the premise that makes it a cached-only problem, so it's hard to tell whether the eager map has the same bug lurking.

Chasing that down, the reason the comment has to work so hard is that `CachedLineageMap.get` reimplements bookkeeping `LineageMap.register` already does: get-or-create a lineage, share it across every tool_id with the same versionless guid, key the map under both. Same rule, written twice — and it's the rule `ToolSection.copy(merge_tools=True)` depends on for panel dedup, so drift between the two copies is the kind that surfaces as `test_only_latest_version_in_panel_fastp` failing rather than as anything obvious.

## What this does

Extracts `LineageMap._shared_lineage(tool_id, build)`. Each caller now expresses only its real difference — **where versions come from**:

```python
# LineageMap.register — from the Tool being loaded
lineage = self._shared_lineage(tool_id, lambda: ToolLineage.from_tool(tool))
lineage.register_version(tool.version)

# CachedLineageMap.get — from the index
lineage = self._shared_lineage(tool_id, lambda: ToolLineage(tool_id))
for version in versions:
    if version:
        lineage.register_version(version)
```

Net −10 lines; the 30-line comment block becomes 11 and can lead with the premise it was missing:

> An eager toolbox seeds every version through `register` as it loads tools, so `LineageMap.get` is only ever a lookup. Nothing walks the tools here, so `get` is the construction path and has to source versions from the index — the inherited fallback would build a lineage from a single just-loaded `Tool` and memoise it, freezing `tool_versions` at one entry and hiding the rest.

## Behavior preservation

Refactoring a shared-mutable-state helper on someone else's branch deserves more than "tests pass", so I ran a differential harness: original and refactored implementations side by side over **every permutation of up to 4 operations** drawn from 7 `register`s + 10 `get`s — shed guids with siblings, `__BUILD_LIST__`, non-guid ids like `cat1`, unindexed ids, and a `versions_for` that raises. It compares return values *and* final map state including lineage object identity.

**122,978 sequences, 0 divergences.**

It earned its keep: my first attempt looked up `tool_id` before the versionless key, and the harness immediately found orderings where versions then accumulated into an orphan lineage instead of the shared one — i.e. exactly the sharing invariant the fastp panel test relies on. Easy to ship, hard to spot in review.

Also run: `test_toolbox.py` (38 passed, 2 xpassed), `test_cached_tool.py` (54 passed), mypy clean on the file.

## One thing I deliberately did *not* fix

`register` returns `self.lineage_map[tool_id]`, which isn't always the lineage it just registered into. When `LineageMap.get`'s fallback (the one carrying `TODO: is the fallback really needed`) aliases a tool_id *without* its versionless key, `register` accumulates versions into the shared lineage but hands the caller the orphan.

That's pre-existing on `dev`, and the dedup just makes it visible — hence the comment I left on the return. `register_tool` callers that bypass lineage registration (e.g. `datatypes/registry.py` for converters) look like the way to reach it, though converter ids usually have no `/` so `remove_version_from_guid` returns `None` and the divergence can't arise. Seems worth its own look, out of scope here.

Happy to also land the sharing invariant as a real unit test if you'd like it pinned down — the harness is throwaway, but the property it checks isn't.
