### PR TITLE
Test first startup from installed Galaxy packages

### DIFF
--- a/.ci/installed_startup.sh
+++ b/.ci/installed_startup.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VENV=${1:?usage: $0 VENV}
+PYTHON="$VENV/bin/python"
+GALAXY="$VENV/bin/galaxy"
+URL=http://localhost:8080
+TRIES=120
+WORK_DIR=$(mktemp -d -t galaxy-installed-startupXXXXXX)
+LOG_FILE="$WORK_DIR/galaxy.log"
+GALAXY_PID=
+
+cleanup() {
+    exit_code=$?
+    if [ -n "$GALAXY_PID" ]; then
+        kill "$GALAXY_PID" 2>/dev/null || true
+        wait "$GALAXY_PID" 2>/dev/null || true
+    fi
+    if [ "$exit_code" -ne 0 ] && [ -f "$LOG_FILE" ]; then
+        echo "Installed Galaxy startup failed; showing $LOG_FILE:"
+        cat "$LOG_FILE"
+    fi
+    rm -rf "$WORK_DIR"
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+"$PYTHON" - <<'PY'
+import sys
+from pathlib import Path
+
+import galaxy.web_client
+
+package_path = Path(galaxy.web_client.__file__).resolve()
+venv_path = Path(sys.prefix).resolve()
+if not package_path.is_relative_to(venv_path):
+    raise SystemExit(f"galaxy.web_client resolved outside the installed environment: {package_path}")
+PY
+
+ASSET=$(
+    "$PYTHON" - <<'PY'
+from importlib.resources import files
+
+dist = files("galaxy.web_client").joinpath("dist")
+print(next(asset.name for asset in dist.iterdir() if asset.name.startswith("galaxy-app-") and asset.name.endswith(".js")))
+PY
+)
+
+cd "$WORK_DIR"
+export GALAXY_CONFIG_DATABASE_AUTO_MIGRATE=true
+export PATH="$VENV/bin:$PATH"
+"$GALAXY" >"$LOG_FILE" 2>&1 &
+GALAXY_PID=$!
+
+for ((i = 0; i <= TRIES; i++)); do
+    if curl --fail --max-time 1 --silent --output /dev/null "$URL/api/version"; then
+        curl --fail --max-time 5 --silent --output /dev/null "$URL/"
+        curl --fail --max-time 5 --silent --output /dev/null "$URL/static/dist/$ASSET"
+        exit 0
+    fi
+    if ! kill -0 "$GALAXY_PID" 2>/dev/null; then
+        echo "Installed Galaxy exited before becoming ready." >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "Installed Galaxy did not become ready after $TRIES seconds." >&2
+exit 1

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -4,12 +4,10 @@ on:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
-      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
-      - 'packages/**'
 env:
   YARN_INSTALL_OPTS: --frozen-lockfile
 concurrency:
@@ -54,4 +52,29 @@ jobs:
         run: uv tool install tox --with tox-uv
       - name: run tests
         run: tox -e first_startup
+        working-directory: 'galaxy root'
+  installed-test:
+    name: Installed startup test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: 'galaxy root'
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install release tooling
+        run: uv tool install galaxy-release-util==0.4.2
+      - name: Build and install Galaxy packages
+        run: make install-packages VENV="$RUNNER_TEMP/galaxy-installed"
+        working-directory: 'galaxy root'
+      - name: Start installed Galaxy
+        run: .ci/installed_startup.sh "$RUNNER_TEMP/galaxy-installed"
         working-directory: 'galaxy root'

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,9 @@ update-navigation-schema: client-node-deps
 install-client: ## Install prebuilt client wheel from PyPI matching the current Galaxy version
 	$(IN_VENV) pip install "galaxy-web-client==$$(PYTHONPATH=lib python -c 'from galaxy.version import VERSION; print(VERSION)')"
 
+install-packages: ## Build and install Galaxy packages from this checkout into VENV
+	cd packages && VENV="$(abspath $(VENV))" ./package-build-install.sh -m
+
 client: client-node-deps ## Rebuild client-side artifacts for local development.
 	$(IN_VENV) cd client && $(NODE_ENV) pnpm run build
 

--- a/packages/meta/setup.cfg
+++ b/packages/meta/setup.cfg
@@ -12,6 +12,7 @@ url = https://github.com/galaxyproject/galaxy
 version = 26.1.1.dev0
 
 [options]
+install_requires = file: requirements.txt
 include_package_data = True
 packages = find:
 python_requires = >=3.10

--- a/packages/package-build-install.sh
+++ b/packages/package-build-install.sh
@@ -8,7 +8,6 @@
 set -euo pipefail
 
 : "${PACKAGE_LIST_FILE:=packages_by_dep_dag.txt}"
-: "${PIP_EXTRA_ARGS:=--extra-index-url https://wheels.galaxyproject.org}"
 #: ${SETUP_VENV:=true}
 
 INSTALL=true
@@ -16,18 +15,53 @@ EDITABLE=false
 META=false
 WHEELHOUSE=
 
-if command -v uv >/dev/null; then
-    VENV_CMD="$(command -v uv) venv"
-    PIP_CMD="$(command -v uv) pip"
-else
-    VENV_CMD='python3 -m venv'
-    PIP_CMD='pip'
+# Use one environment for package build dependencies and the installed Galaxy.
+: "${VENV=../.venv}"
+case "$VENV" in
+    /*) ;;
+    *) VENV="$(pwd)/$VENV" ;;
+esac
+export VENV
+
+if [ -z "${PIP_EXTRA_ARGS:-}" ]; then
+    if command -v uv >/dev/null; then
+        PIP_EXTRA_ARGS="--index-strategy unsafe-best-match --extra-index-url https://wheels.galaxyproject.org/simple"
+    else
+        PIP_EXTRA_ARGS="--extra-index-url https://wheels.galaxyproject.org/simple"
+    fi
 fi
 
-# Prevent making a venv for build deps for each package, Used inside the package dir, so refers to
-# <source_root>/packages/.venv
-: "${VENV=../.venv}"
-export VENV
+ensure_venv() {
+    if [ ! -d "$VENV" ]; then
+        if command -v uv >/dev/null; then
+            uv venv "$VENV"
+        else
+            python3 -m venv "$VENV"
+        fi
+    fi
+}
+
+pip_install() {
+    ensure_venv
+    if command -v uv >/dev/null; then
+        uv pip install --python "$VENV/bin/python" "$@"
+    else
+        "$VENV/bin/python" -m pip install "$@"
+    fi
+}
+
+build_release_packages() {
+    if command -v galaxy-release-util >/dev/null && galaxy-release-util --help >/dev/null 2>&1; then
+        galaxy-release-util build --galaxy-root ..
+    elif command -v uvx >/dev/null; then
+        local release_util_requirement
+        release_util_requirement=$(grep '^galaxy-release-util==' ../lib/galaxy/dependencies/dev-requirements.txt)
+        uvx --from "$release_util_requirement" galaxy-release-util build --galaxy-root ..
+    else
+        echo "ERROR: galaxy-release-util is required to build the Galaxy metapackage." >&2
+        exit 1
+    fi
+}
 
 trap_handler() {
     if [ -n "$WHEELHOUSE" ]; then
@@ -70,30 +104,34 @@ if [ -n "$up_to" ] && [ ! -d "$up_to" ]; then
     exit 1
 fi
 
-while read -r package; do
-    [ -n "$package" ] || continue
-    if $INSTALL && [[ $package == meta ]] && ! $META; then continue; fi
-    printf "\n========= PACKAGE %s =========\n\n" "$package"
-    pushd "$package"
-    if $EDITABLE; then
-        ${PIP_CMD} install -e .
-    else
-        if [ ! -d "$VENV" ]; then
-            ${VENV_CMD} "$VENV"
-            VIRTUAL_ENV="${VENV}" ${PIP_CMD} install -r dev-requirements.txt
+if $META && ! $EDITABLE; then
+    build_release_packages
+else
+    while read -r package; do
+        [ -n "$package" ] || continue
+        if $INSTALL && [[ $package == meta ]] && ! $META; then continue; fi
+        printf "\n========= PACKAGE %s =========\n\n" "$package"
+        pushd "$package"
+        if $EDITABLE; then
+            pip_install -e .
+        else
+            if [ ! -d "$VENV" ]; then
+                ensure_venv
+                pip_install -r dev-requirements.txt
+            fi
+            make dist
+            if $INSTALL && ! $META; then
+                pip_install dist/*.whl
+            fi
         fi
-        make dist
-        if $INSTALL && ! $META; then
-            ${PIP_CMD} install dist/*.whl
-        fi
-    fi
-    popd
-    [ "$package" != "$up_to" ] || exit
-done < "$PACKAGE_LIST_FILE"
+        popd
+        [ "$package" != "$up_to" ] || exit
+    done < "$PACKAGE_LIST_FILE"
+fi
 
 if $INSTALL && $META && ! $EDITABLE; then
     WHEELHOUSE=$(mktemp -d -t gxpkgwheelhouseXXXXXX)
     cp ./*/dist/*.whl "$WHEELHOUSE"
     # shellcheck disable=SC2086
-    ${PIP_CMD} install ${PIP_EXTRA_ARGS} --find-links "$WHEELHOUSE" meta/dist/*.whl
+    pip_install ${PIP_EXTRA_ARGS} --find-links "$WHEELHOUSE" meta/dist/*.whl
 fi


### PR DESCRIPTION
## Summary

- add a reusable make install-packages target backed by galaxy-release-util and a local wheelhouse
- configure the Galaxy metapackage to consume generated pinned requirements
- add Python 3.14 CI coverage that runs the installed galaxy command without explicit configuration and verifies the API, root page, and packaged web client asset

## Testing

- make install-packages VENV=/tmp/galaxy-installed-web-client-wheel-assets
- .ci/installed_startup.sh /tmp/galaxy-installed-web-client-wheel-assets
- shell syntax checks, workflow YAML parsing, and git diff --check